### PR TITLE
Replace tsconfig deprecated options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "esModuleInterop": true,
-    "importsNotUsedAsValues": "error",
+    "verbatimModuleSyntax": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
     "lib": ["esnext"],


### PR DESCRIPTION
# Description

removing `importsNotUsedAsValues` and using `verbatimModuleSyntax` instead.