### PR TITLE
Build Fails: Need Android Script in Build Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ npm install react-native-zendesk-messaging
 yarn add react-native-zendesk-messaging
 ```
 
+For Android, add the following script inside `android/build.gradle`
+```
+allprojects {
+    repositories {
+        maven {
+            url "https://zendesk.jfrog.io/artifactory/repo"
+        }
+    }
+}
+```
 ## Getting Started
 
 Read [Getting Started Guide](./docs/getting-started.md).


### PR DESCRIPTION
- Update README.md to add instruction for adding Android script to android/build.gradle
- Android build failed prior to adding this script
- Failed build resolved after adding this script