### PR TITLE
Add Android ReactMethod

### DIFF
--- a/android/src/main/java/dev/geundung/zendesk/messaging/ZendeskMessagingModule.kt
+++ b/android/src/main/java/dev/geundung/zendesk/messaging/ZendeskMessagingModule.kt
@@ -207,6 +207,17 @@ class ZendeskMessagingModule(private val reactContext: ReactApplicationContext) 
     }
   }
 
+  @ReactMethod
+  fun addListener(type: String?) {
+      // noop
+  }
+
+  @ReactMethod
+  fun removeListeners(type: Int?) {
+      // noop
+  }
+
+
   companion object {
     const val NAME = "ZendeskMessaging"
   }


### PR DESCRIPTION
add event listners for resolve below warning message
```
WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.
WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.
```