### PR TITLE
Close messaging view on iOS

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -302,7 +302,7 @@ PODS:
   - React-jsinspector (0.70.6)
   - React-logger (0.70.6):
     - glog
-  - react-native-zendesk-messaging (0.1.2):
+  - react-native-zendesk-messaging (0.2.1):
     - React-Core
     - ZendeskSDKMessaging (= 2.13.0)
   - React-perflogger (0.70.6)
@@ -598,7 +598,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b4a65947391c658450151275aa406f2b8263178f
   React-jsinspector: 60769e5a0a6d4b32294a2456077f59d0266f9a8b
   React-logger: 1623c216abaa88974afce404dc8f479406bbc3a0
-  react-native-zendesk-messaging: ea81846bc38a4778218d02ba037b967059dcb374
+  react-native-zendesk-messaging: e4418f96cb02c6741cce7059972f01312eac8e0f
   React-perflogger: 8c79399b0500a30ee8152d0f9f11beae7fc36595
   React-RCTActionSheet: 7316773acabb374642b926c19aef1c115df5c466
   React-RCTAnimation: 5341e288375451297057391227f691d9b2326c3d
@@ -627,4 +627,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 95ff72db15f9303f9feae89ece9cba53e19302a2
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.13.0

--- a/ios/ZendeskMessaging.m
+++ b/ios/ZendeskMessaging.m
@@ -20,6 +20,9 @@ RCT_EXTERN_METHOD(logout:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(openMessagingView:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(closeMessagingView:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(sendPageViewEvent:(NSDictionary*)event
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/ZendeskMessaging.swift
+++ b/ios/ZendeskMessaging.swift
@@ -147,6 +147,26 @@ class ZendeskMessaging: RCTEventEmitter {
     }
   }
 
+  @objc(closeMessagingView:rejecter:)
+  func closeMessagingView(
+    resolver resolve: @escaping RCTPromiseResolveBlock,
+    rejecter reject: @escaping RCTPromiseRejectBlock
+  ) -> Void {
+    if !initialized {
+      reject(nil, "Zendesk instance not initialized", nil)
+      return
+    }
+
+    DispatchQueue.main.async {
+      guard let rootController = RCTPresentedViewController() else {
+        reject(nil, "cannot close messaging view", nil)
+        return
+      }
+      rootController.dismiss(animated: true, completion: nil)
+      resolve(nil)
+    }
+  }
+
   @objc(sendPageViewEvent:resolver:rejecter:)
   func sendPageViewEvent(
     event: [String: String],

--- a/ios/ZendeskMessaging.swift
+++ b/ios/ZendeskMessaging.swift
@@ -158,11 +158,11 @@ class ZendeskMessaging: RCTEventEmitter {
     }
 
     DispatchQueue.main.async {
-      guard let rootController = RCTPresentedViewController() else {
+      guard let rootViewController = UIApplication.shared.keyWindow?.rootViewController else {
         reject(nil, "cannot close messaging view", nil)
         return
       }
-      rootController.dismiss(animated: true, completion: nil)
+      rootViewController.dismiss(animated: true, completion: nil)
       resolve(nil)
     }
   }

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -14,6 +14,7 @@ jest.mock('react-native', () => {
     login: jest.fn(),
     logout: jest.fn(),
     openMessagingView: jest.fn(),
+    closeMessagingView: jest.fn(),
     sendPageViewEvent: jest.fn(),
     setConversationFields: jest.fn(),
     clearConversationFields: jest.fn(),
@@ -119,6 +120,48 @@ describe('react-native-zendesk-messaging', () => {
 
     it('should call native module\'s openMessagingView method', () => {
       expect(mockOpenMessagingView).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when call closeMessagingView', () => {
+    let mockCloseMessagingView: jest.SpyInstance;
+
+    describe('when platform is iOS', () => {
+      beforeAll(() => {
+        Platform.OS = 'ios';
+      });
+
+      beforeEach(async () => {
+        mockCloseMessagingView = jest.spyOn(ZendeskMessagingModule, 'closeMessagingView');
+        await Zendesk.closeMessagingView();
+      });
+
+      afterAll(() => {
+        mockCloseMessagingView.mockClear();
+      });
+
+      it('should call native module\'s openMessagingView method', () => {
+        expect(mockCloseMessagingView).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('when platform is Android', () => {
+      beforeAll(() => {
+        Platform.OS = 'android';
+      });
+
+      beforeEach(async () => {
+        mockCloseMessagingView = jest.spyOn(ZendeskMessagingModule, 'closeMessagingView');
+        await Zendesk.closeMessagingView();
+      });
+
+      afterAll(() => {
+        mockCloseMessagingView.mockClear();
+      });
+
+      it('should call native module\'s openMessagingView method', () => {
+        expect(mockCloseMessagingView).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,20 @@ export function openMessagingView(): Promise<void> {
 }
 
 /**
+ * **iOS Only** (no-op for other platform, always return empty promise)
+ *
+ * Closes the messaging view if it is open. Doesn't work on Android.
+ * Returns a promise that resolves when the messaging view is closed.
+ *
+ * N.B. This is not a part of the official Zendesk SDK, but a custom implementation.
+ */
+
+export function closeMessagingView(): Promise<void> {
+  if (Platform.OS !== 'ios') return Promise.resolve();
+  return ZendeskMessaging.closeMessagingView();
+}
+
+/**
  * Send session-based page view event. event must have `pageTitle` and `url`.
  *
  * @see Android {@link https://developer.zendesk.com/documentation/zendesk-web-widget-sdks/sdks/android/advanced_integration/#page-view-event}


### PR DESCRIPTION
# Description

This PR adds a new, custom method that closes the messaging view on iOS.

> [!NOTE]  
> This is a no-op on Android as there's shouldn't be a way to call this method when the Zendesk chat is active. The Android implementation lives on a separate Activity, thus making the React Native activity inactive.

> [!WARNING]  
> This is not a direct call of the Zendesk SDK but rather a custom methods that directly dismisses the view if open

There's a workaround for Android described [here](https://github.com/leegeunhyeok/react-native-zendesk-messaging/issues/35#issuecomment-1959656255)