### PR TITLE
fix: Select conversation issue on iOS

### DIFF
--- a/ios/ZendeskMessaging.swift
+++ b/ios/ZendeskMessaging.swift
@@ -126,26 +126,31 @@ class ZendeskMessaging: RCTEventEmitter {
     }
   }
 
-  @objc(openMessagingView:rejecter:)
-  func openMessagingView(
-    resolver resolve: @escaping RCTPromiseResolveBlock,
-    rejecter reject: @escaping RCTPromiseRejectBlock
-  ) -> Void {
-    if !initialized {
-      reject(nil, "Zendesk instance not initialized", nil)
+ @objc(openMessagingView:rejecter:)
+func openMessagingView(
+  resolver resolve: @escaping RCTPromiseResolveBlock,
+  rejecter reject: @escaping RCTPromiseRejectBlock
+) -> Void {
+  if !initialized {
+    reject(nil, "Zendesk instance not initialized", nil)
+    return
+  }
+  DispatchQueue.main.async {
+    guard let viewController = ZendeskNativeModule.shared.getMessagingViewController(),
+          let rootController = RCTPresentedViewController() else {
+      reject(nil, "cannot open messaging view", nil)
       return
     }
 
-    DispatchQueue.main.async {
-      guard let viewController = ZendeskNativeModule.shared.getMessagingViewController(),
-            let rootController = RCTPresentedViewController() else {
-        reject(nil, "cannot open messaging view", nil)
-        return
-      }
-      rootController.show(viewController, sender: self)
-      resolve(nil)
+    if let navigationController = rootController.navigationController {
+      navigationController.pushViewController(viewController, animated: true)
+    } else {
+      let navigationController = UINavigationController(rootViewController: viewController)
+      rootController.present(navigationController, animated: true, completion: nil)
     }
+    resolve(nil)
   }
+}
 
   @objc(closeMessagingView:rejecter:)
   func closeMessagingView(

--- a/ios/ZendeskNativeModule.swift
+++ b/ios/ZendeskNativeModule.swift
@@ -181,21 +181,32 @@ class ZendeskNativeModule: NSObject {
   static func openMessageViewByPushNotification(
     _ userInfo: [AnyHashable: Any]? = nil,
     completionHandler: ((Bool) -> Void)? = nil
-  ) -> Void {
+) -> Void {
     guard let userInfo = userInfo ?? receivedUserInfo else {
-      completionHandler?(false)
-      return
-    }
-
-    PushNotifications.handleTap(userInfo) { viewController in
-      receivedUserInfo = nil
-      guard let rootController = RCTPresentedViewController(),
-            let viewController = viewController else {
-        completionHandler?(viewController == nil)
+        completionHandler?(false)
         return
-      }
-      rootController.show(viewController, sender: self)
-      completionHandler?(false)
     }
-  }
+    PushNotifications.handleTap(userInfo) { viewController in
+        receivedUserInfo = nil
+        guard let rootController = RCTPresentedViewController() else {
+            completionHandler?(false)
+            return
+        }
+
+        if let navigationController = rootController as? UINavigationController {
+            if let zendeskVC = viewController {
+                navigationController.pushViewController(zendeskVC, animated: true)
+            } else {
+                completionHandler?(false)
+            }
+        } else {
+            if let zendeskVC = viewController {
+                rootController.show(zendeskVC, sender: self)
+            } else {
+                completionHandler?(false)
+            }
+        }
+        completionHandler?(false)
+    }
+}
 }


### PR DESCRIPTION
On Android, the Zendesk messaging view worked as expected because it was displayed as part of the regular screen flow. On iOS, using rootController.show(viewController, sender: self) pushed the Zendesk view onto the navigation stack. However, the Zendesk view was just a single screen, and there was no deeper navigation (i.e., tapping on a conversation to open a detailed view), so the interaction issues didn't appear. After the update that introduced multi-conversation support, where tapping on a conversation opens a deeper screen, the previous approach caused issues because the Zendesk view was not properly integrated into the app's navigation stack. This prevented the deeper navigation from functioning correctly (e.g., tapping on a conversation didn't lead to a new screen).

Solution:

1. We checked if a UINavigationController was available in the app.
2. If a UINavigationController was present, we pushed the Zendesk view onto the navigation stack, allowing for proper
navigation (e.g., tapping on a conversation now pushes a new screen).
3. If no UINavigationController was found, we ensured the Zendesk view was presented fullscreen, but still part of the normal navigation context.

This fix resolves the interaction issue by ensuring the Zendesk view is correctly integrated into the app’s navigation stack, enabling the deeper screen navigation introduced by the multi-conversation update and providing a smooth user experience.