### PR TITLE
fix: ZendeskMessaging objects outside of class

### DIFF
--- a/ios/ZendeskMessaging.swift
+++ b/ios/ZendeskMessaging.swift
@@ -152,7 +152,6 @@ class ZendeskMessaging: RCTEventEmitter {
       resolve(nil)
     }
   }
-}
 
   @objc(closeMessagingView:rejecter:)
   func closeMessagingView(


### PR DESCRIPTION
[Open issue #79 ](https://github.com/leegeunhyeok/react-native-zendesk-messaging/issues/79)